### PR TITLE
Add products table migration with RLS and policies

### DIFF
--- a/supabase/migrations/20250810190024_products.sql
+++ b/supabase/migrations/20250810190024_products.sql
@@ -1,0 +1,27 @@
+-- Migration for products table and policies
+create table if not exists products (
+  id uuid primary key default gen_random_uuid(),
+  name text,
+  description text,
+  price numeric,
+  image_url text,
+  created_at timestamptz default now()
+);
+
+alter table products enable row level security;
+
+create policy "Public read access on products" on products
+  for select
+  using (true);
+
+create policy "Only admin can insert products" on products
+  for insert
+  with check (auth.jwt() ->> 'role' = 'admin');
+
+create policy "Only admin can update products" on products
+  for update
+  using (auth.jwt() ->> 'role' = 'admin');
+
+create policy "Only admin can delete products" on products
+  for delete
+  using (auth.jwt() ->> 'role' = 'admin');


### PR DESCRIPTION
## Summary
- add migration for `products` table
- enforce RLS with public read and admin-only write operations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 17 problems (9 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6898ec03b34c8325b8e1b10e3a13e8b0