### PR TITLE
feat: add admin product management

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -5,7 +5,7 @@ type SEOProps = {
   title: string;
   description?: string;
   path?: string;
-  structuredData?: Record<string, any>;
+  structuredData?: Record<string, unknown>;
 };
 
 export const SEO = ({ title, description, path, structuredData }: SEOProps) => {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -45,8 +45,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   const isAdmin = useMemo(() => {
-    const roles = (user?.app_metadata as any)?.roles as string[] | undefined;
-    const metaRole = (user?.user_metadata as any)?.role as string | undefined;
+    const roles = (user?.app_metadata as { roles?: string[] } | undefined)?.roles;
+    const metaRole = (user?.user_metadata as { role?: string } | undefined)?.role;
     return roles?.includes("admin") || metaRole === "admin" || false;
   }, [user]);
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,9 +1,16 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
+declare global {
+  interface Window {
+    __SUPABASE_URL__?: string;
+    __SUPABASE_ANON_KEY__?: string;
+  }
+}
+
 // Lovable Supabase integration: if connected, these globals will be provided.
 // We guard against missing values so the app still renders with guidance.
-const SUPABASE_URL = (window as any).__SUPABASE_URL__ || "";
-const SUPABASE_ANON_KEY = (window as any).__SUPABASE_ANON_KEY__ || "";
+const SUPABASE_URL = window.__SUPABASE_URL__ || "";
+const SUPABASE_ANON_KEY = window.__SUPABASE_ANON_KEY__ || "";
 
 let client: SupabaseClient | null = null;
 if (SUPABASE_URL && SUPABASE_ANON_KEY) {

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,15 +1,372 @@
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { SEO } from "@/components/SEO";
+import { supabase } from "@/lib/supabaseClient";
+import { toast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type Product = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number | null;
+  image_url: string | null;
+  created_at: string;
+};
+
+type ProductFormValues = {
+  name: string;
+  description: string;
+  price: string;
+  image_url: string;
+};
+
+const fetchProducts = async (): Promise<Product[]> => {
+  const { data, error } = await supabase!
+    .from("products")
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return data as Product[];
+};
+
+const CreateProductDialog = () => {
+  const [open, setOpen] = useState(false);
+  const form = useForm<ProductFormValues>({
+    defaultValues: { name: "", description: "", price: "", image_url: "" },
+  });
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (values: ProductFormValues) => {
+      const { error } = await supabase!.from("products").insert({
+        name: values.name,
+        description: values.description,
+        price: values.price ? Number(values.price) : null,
+        image_url: values.image_url,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+      toast({ title: "Product created" });
+      form.reset();
+      setOpen(false);
+    },
+    onError: (err: unknown) =>
+      toast({
+        title: "Error",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      }),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>New Product</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Product</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="price"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Price</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="image_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Image URL</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={mutation.isPending}>
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const EditProductDialog = ({ product }: { product: Product }) => {
+  const [open, setOpen] = useState(false);
+  const form = useForm<ProductFormValues>({
+    defaultValues: {
+      name: product.name ?? "",
+      description: product.description ?? "",
+      price: product.price?.toString() ?? "",
+      image_url: product.image_url ?? "",
+    },
+  });
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    form.reset({
+      name: product.name ?? "",
+      description: product.description ?? "",
+      price: product.price?.toString() ?? "",
+      image_url: product.image_url ?? "",
+    });
+  }, [product, form]);
+
+  const mutation = useMutation({
+    mutationFn: async (values: ProductFormValues) => {
+      const { error } = await supabase!
+        .from("products")
+        .update({
+          name: values.name,
+          description: values.description,
+          price: values.price ? Number(values.price) : null,
+          image_url: values.image_url,
+        })
+        .eq("id", product.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+      toast({ title: "Product updated" });
+      setOpen(false);
+    },
+    onError: (err: unknown) =>
+      toast({
+        title: "Error",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      }),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Edit
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Product</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+            className="space-y-4"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="price"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Price</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="image_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Image URL</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={mutation.isPending}>
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 const Admin = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["products"],
+    queryFn: fetchProducts,
+  });
+
+  const queryClient = useQueryClient();
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase!.from("products").delete().eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["products"] });
+      toast({ title: "Product deleted" });
+    },
+    onError: (err: unknown) =>
+      toast({
+        title: "Error",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      }),
+  });
+
   return (
     <>
-      <SEO title="Admin — Savage Nation USA" description="Admin dashboard to manage Savage Nation USA." />
+      <SEO
+        title="Admin — Savage Nation USA"
+        description="Admin dashboard to manage Savage Nation USA."
+      />
       <main className="container mx-auto py-12">
-        <h1 className="text-3xl font-semibold tracking-tight mb-6">Admin Dashboard</h1>
-        <p className="text-muted-foreground">Welcome, admin. Manage products, content, media, and blog posts here. (Coming soon)</p>
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-semibold tracking-tight">Products</h1>
+          <CreateProductDialog />
+        </div>
+        {isLoading ? (
+          <p className="text-muted-foreground">Loading...</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead>Price</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data?.map((product) => (
+                <TableRow key={product.id}>
+                  <TableCell className="font-medium">{product.name}</TableCell>
+                  <TableCell>{product.description}</TableCell>
+                  <TableCell>
+                    {product.price != null ? `$${product.price}` : ""}
+                  </TableCell>
+                  <TableCell className="text-right space-x-2">
+                    <EditProductDialog product={product} />
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => deleteMutation.mutate(product.id)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </main>
     </>
   );
 };
 
 export default Admin;
+

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -23,9 +23,9 @@ const Auth = () => {
     const action = mode === "signin" ? signIn : signUp;
     const { error } = await action(email, password);
     setLoading(false);
-    if (error) {
-      toast({ title: "Error", description: error, variant: "destructive" as any });
-    } else {
+      if (error) {
+        toast({ title: "Error", description: error, variant: "destructive" });
+      } else {
       toast({ title: "Success", description: mode === "signin" ? "Signed in" : "Account created. Check your email if confirmation is required." });
     }
   };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -94,5 +95,5 @@ export default {
 				}
 			}
 		},
-	plugins: [require("tailwindcss-animate")],
-} satisfies Config;
+        plugins: [animate],
+        } satisfies Config;


### PR DESCRIPTION
## Summary
- build products admin dashboard with listing, editing and creation dialogs
- integrate Supabase CRUD and React Query cache invalidation
- tidy up type usages and switch Tailwind plugin to ESM import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898edb62a808325855c3270e9cbb398