### PR TITLE
Enable product image uploads and storefront display

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,20 +1,61 @@
 import { SEO } from "@/components/SEO";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabaseClient";
+
+type Product = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number | null;
+  image_url: string | null;
+};
+
+const fetchProducts = async (): Promise<Product[]> => {
+  const { data, error } = await supabase!
+    .from("products")
+    .select("*")
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+  return data as Product[];
+};
 
 const Store = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: ["store-products"],
+    queryFn: fetchProducts,
+  });
+
   return (
     <main className="container mx-auto py-10">
-      <SEO title="Store — Savage Nation USA" description="Shop patriotic apparel and gear from Savage Nation USA." />
+      <SEO
+        title="Store — Savage Nation USA"
+        description="Shop patriotic apparel and gear from Savage Nation USA."
+      />
       <h1 className="text-4xl font-bold mb-6">Store</h1>
-      <p className="text-muted-foreground mb-8">Our full e‑commerce experience is coming soon. Browse featured products below.</p>
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {[1,2,3,4,5,6].map((i) => (
-          <div key={i} className="rounded-lg border p-6 shadow-sm hover:shadow-elevated transition-shadow">
-            <div className="aspect-[4/3] bg-muted rounded-md mb-4" />
-            <div className="font-medium">Patriotic Tee {i}</div>
-            <div className="text-muted-foreground text-sm">Premium cotton blend</div>
-          </div>
-        ))}
-      </div>
+      {isLoading ? (
+        <p className="text-muted-foreground mb-8">Loading...</p>
+      ) : (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {data?.map((product) => (
+            <div
+              key={product.id}
+              className="rounded-lg border p-6 shadow-sm hover:shadow-elevated transition-shadow"
+            >
+              {product.image_url && (
+                <img
+                  src={product.image_url}
+                  alt={product.name}
+                  className="mb-4 aspect-[4/3] w-full object-cover rounded-md"
+                />
+              )}
+              <div className="font-medium">{product.name}</div>
+              <div className="text-muted-foreground text-sm">
+                {product.description}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </main>
   );
 };

--- a/supabase/migrations/20250810190025_product_images_bucket.sql
+++ b/supabase/migrations/20250810190025_product_images_bucket.sql
@@ -1,0 +1,11 @@
+-- Migration for product-images bucket and policies
+insert into storage.buckets (id, name, public)
+values ('product-images', 'product-images', true)
+on conflict (id) do nothing;
+
+create policy "Public read access on product images" on storage.objects
+  for select using (bucket_id = 'product-images');
+
+create policy "Admin manage product images" on storage.objects
+  for all using ((auth.jwt() ->> 'role' = 'admin') and bucket_id = 'product-images')
+  with check ((auth.jwt() ->> 'role' = 'admin') and bucket_id = 'product-images');


### PR DESCRIPTION
## Summary
- add Supabase migration for `product-images` bucket with public read policies
- upload product images in admin form and persist public URL
- fetch and show product images in admin listing and storefront

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f7ccb2ec8325bead67c451fb2998