### PR TITLE
feat: display products with skeleton loading

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,31 @@
+import { type FC } from "react";
+
+export type Product = {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number | null;
+  image_url: string | null;
+};
+
+interface ProductCardProps {
+  product: Product;
+}
+
+export const ProductCard: FC<ProductCardProps> = ({ product }) => {
+  return (
+    <div className="rounded-lg border p-6 shadow-sm hover:shadow-elevated transition-shadow">
+      {product.image_url && (
+        <img
+          src={product.image_url}
+          alt={product.name}
+          className="mb-4 aspect-[4/3] w-full object-cover rounded-md"
+        />
+      )}
+      <div className="font-medium">{product.name}</div>
+      <div className="text-muted-foreground text-sm">
+        {product.description}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,14 +1,8 @@
 import { SEO } from "@/components/SEO";
+import { ProductCard, type Product } from "@/components/ProductCard";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabaseClient";
-
-type Product = {
-  id: string;
-  name: string;
-  description: string | null;
-  price: number | null;
-  image_url: string | null;
-};
 
 const fetchProducts = async (): Promise<Product[]> => {
   const { data, error } = await supabase!
@@ -20,10 +14,7 @@ const fetchProducts = async (): Promise<Product[]> => {
 };
 
 const Store = () => {
-  const { data, isLoading } = useQuery({
-    queryKey: ["store-products"],
-    queryFn: fetchProducts,
-  });
+  const { data, isLoading, error } = useQuery<Product[]>(["products"], fetchProducts);
 
   return (
     <main className="container mx-auto py-10">
@@ -33,26 +24,24 @@ const Store = () => {
       />
       <h1 className="text-4xl font-bold mb-6">Store</h1>
       {isLoading ? (
-        <p className="text-muted-foreground mb-8">Loading...</p>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-lg border p-6 shadow-sm hover:shadow-elevated transition-shadow"
+            >
+              <Skeleton className="mb-4 aspect-[4/3] w-full rounded-md" />
+              <Skeleton className="h-4 w-2/3 mb-2" />
+              <Skeleton className="h-3 w-full" />
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-destructive mb-8">Failed to load products.</p>
       ) : (
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {data?.map((product) => (
-            <div
-              key={product.id}
-              className="rounded-lg border p-6 shadow-sm hover:shadow-elevated transition-shadow"
-            >
-              {product.image_url && (
-                <img
-                  src={product.image_url}
-                  alt={product.name}
-                  className="mb-4 aspect-[4/3] w-full object-cover rounded-md"
-                />
-              )}
-              <div className="font-medium">{product.name}</div>
-              <div className="text-muted-foreground text-sm">
-                {product.description}
-              </div>
-            </div>
+            <ProductCard key={product.id} product={product} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- fetch products from Supabase using `useQuery(["products"], ...)`
- render list with new `ProductCard` component
- show skeleton placeholders and error message on failure

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898fa0d9b608325ade7a043a4e107dd